### PR TITLE
More friendly and clean check_word

### DIFF
--- a/db.py
+++ b/db.py
@@ -37,22 +37,10 @@ def try_execute(cursor: sqlite3.Cursor, sql: str, parameters: Iterable = ...):
 
 
 def check_word(word: str):
-    def check_rus(word):
-        for c in word:
-            if not (('а' <= c <= 'я') or c == '-' or c == 'ё'):
-                return False
-        return True
-
-    def check_en(word):
-        for c in word:
-            if not (('a' <= c <= 'z') or c == '-'):
-                return False
-        return True
-
     if not len(word):
         return False
 
-    return check_rus(word) or check_en(word)
+    return all(c.isalpha() or c == '-' for c in word)
 
 
 def get_local_cursor(data, db_file):

--- a/test_db.py
+++ b/test_db.py
@@ -16,25 +16,36 @@ class TestDb(unittest.TestCase):
     def test_db(self):
         hat, game = start_game(self.db_file)
         self.assertIsNone(game.room_for_player(1))
+
         game.add_player(1, "room1")
         game.add_player(3, "room2")
         game.add_player(2, "room1")
         game.add_player(4, "room2")
+
         self.assertEqual(game.room_size("room1"), 2)
         self.assertEqual(game.room_size("room2"), 2)
         self.assertEqual(game.room_for_player(2), "room1")
         self.assertIsNone(hat.get_word("room1"))
+
         self.assertTrue(hat.add_word("первое", 1, "room1"))
         self.assertTrue(hat.add_word("second", 1, "room1"))
         self.assertEqual(hat.words_in_hat("room1"), 2)
         self.assertTrue(hat.add_word("треТье", 1, "room1"))
         self.assertFalse(hat.remove_word("кусь", "room1"))
-        self.assertTrue(hat.add_word("чеТвертое", 1, "room1"))
+        self.assertTrue(hat.add_word("четвёртое-Ё-моё", 1, "room1"))
         self.assertTrue(hat.add_word("пятое", 1, "room1"))
         self.assertTrue(hat.remove_word("пятое", "room1"))
-        self.assertFalse(hat.add_word("qcь", 1, "room1"))
+        self.assertTrue(hat.add_word("sixième", 1, "room1"))
+        self.assertTrue(hat.add_word("第七", 1, "room1"))
+
+        self.assertFalse(hat.add_word("родитель1", 1, "room1"))
+        self.assertFalse(hat.add_word("два слова", 1, "room1"))
+        self.assertFalse(hat.add_word("not_word", 1, "room1"))
         self.assertFalse(hat.add_word("", 1, "room1"))
         self.assertFalse(hat.add_word("первое", 1, "room1"))
+
+        self.assertTrue(hat.get_word("room1"))
+        self.assertTrue(hat.get_word("room1"))
         self.assertTrue(hat.get_word("room1"))
         self.assertTrue(hat.get_word("room1"))
         self.assertTrue(hat.get_word("room1"))


### PR DESCRIPTION
Заменил странную проверку в `check_word` на более общую и чуть менее странную.
Кейс со словом, содержащим латиницу и кириллицу вперемежку, мне кажется слишком надуманным. Не вижу смысла это проверять, от банальных опечаток всё равно не защититься.